### PR TITLE
Alternative Dai token with signature transfer functionality

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "lib/ds-weth"]
 	path = lib/ds-weth
 	url = https://github.com/dapphub/ds-weth
+[submodule "lib/tokens"]
+	path = lib/tokens
+	url = git@github.com:mrchico/tokens

--- a/bin/deploy
+++ b/bin/deploy
@@ -62,5 +62,5 @@ export MCD_SPOT=0x$(seth call "$MCD_DEPLOY" "spotter()(address)")
 export MCD_POT=0x$(seth call "$MCD_DEPLOY" "pot()(address)")
 export MCD_MOM=0x$(seth call "$MCD_DEPLOY" "mom()(address)")
 export MCD_DAI=0x$(seth call "$MCD_DEPLOY" "dai()(address)")
-export MCD_DAI_GUARD=0x$(seth call "$MCD_DEPLOY" "guard()(address)")
+export MCD_GUARD=0x$(seth call "$MCD_DEPLOY" "guard()(address)")
 EOF

--- a/src/DssDeploy.t.base.sol
+++ b/src/DssDeploy.t.base.sol
@@ -110,7 +110,7 @@ contract DssDeployTestBase is DSTest {
     Cat cat;
     Flapper flap;
     Flopper flop;
-    DSToken dai;
+    ERC20   dai;
     DaiJoin daiJoin;
     DaiMove daiMove;
     Spotter spotter;
@@ -201,6 +201,7 @@ contract DssDeployTestBase is DSTest {
     function deploy() public {
         dssDeploy.deployVat();
         dssDeploy.deployDai();
+        dssDeploy.deployGuard();
         dssDeploy.deployTaxation(address(gov));
         dssDeploy.deployLiquidation(address(gov));
         dssDeploy.deployMom(authority);

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -498,9 +498,7 @@ contract DssDeployTest is DssDeployTestBase {
         assertEq(vat.wards(address(spotter)), 1);
 
         // dai
-        assertEq(address(dai.authority()), address(guard));
-        assertTrue(guard.canCall(address(daiJoin), address(dai), bytes4(keccak256("mint(address,uint256)"))));
-        assertTrue(guard.canCall(address(daiJoin), address(dai), bytes4(keccak256("burn(address,uint256)"))));
+        assertEq(dai.wards(address(daiJoin)), 1);
 
         // flop
         assertEq(flop.wards(address(dssDeploy)), 1);


### PR DESCRIPTION
Adds a fairly simple token contract https://github.com/MrChico/tokens/ which includes a logic for sending dai via cheques. 
Cheques are in a ERC712 compatible format (meaning they look nice in metamask for example). Example generation code in the submodule repo. 

The token uses the simpler deny-rely auth scheme rather than ds-auth. The only protected function is `mint`.