### PR TITLE
Abstract `dapp build` and fix setting `--optimize` when building with Nix

### DIFF
--- a/bin/deploy-core
+++ b/bin/deploy-core
@@ -6,7 +6,7 @@
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 export SOLC_FLAGS="--optimize"
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 # Check that all fabs are defined
 { test -z "$VAT_FAB"    || test -z "$JUG_FAB"     || test -z "$VOW_FAB" || \

--- a/bin/deploy-fab
+++ b/bin/deploy-fab
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 export SETH_ASYNC=yes
 

--- a/bin/deploy-ilk
+++ b/bin/deploy-ilk
@@ -4,7 +4,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 { test -z "$1" || test -z "$2" || test -z "$3"; } && exit 1
 

--- a/bin/deploy-ilk-col1
+++ b/bin/deploy-ilk-col1
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 test -z "$COL1" && COL1=$(dapp create Token1 "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")")
 test -z "$PIP_COL1" && PIP_COL1=$(dapp create DSValue)

--- a/bin/deploy-ilk-col2
+++ b/bin/deploy-ilk-col2
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 test -z "$COL2" && COL2=$(dapp create Token2 "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")")
 test -z "$PIP_COL2" && PIP_COL2=$(dapp create DSValue)

--- a/bin/deploy-ilk-col3
+++ b/bin/deploy-ilk-col3
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 test -z "$COL3" && COL3=$(dapp create Token3 "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")")
 test -z "$PIP_COL3" && PIP_COL3=$(dapp create DSValue)

--- a/bin/deploy-ilk-col4
+++ b/bin/deploy-ilk-col4
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 test -z "$COL4" && COL4=$(dapp create Token4 "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")")
 test -z "$PIP_COL4" && PIP_COL4=$(dapp create DSValue)

--- a/bin/deploy-ilk-col5
+++ b/bin/deploy-ilk-col5
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 test -z "$COL5" && COL5=$(dapp create Token5 "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")")
 test -z "$PIP_COL5" && PIP_COL5=$(dapp create DSValue)

--- a/bin/deploy-ilk-eth
+++ b/bin/deploy-ilk-eth
@@ -5,7 +5,7 @@
 
 export ETH_FROM=${ETH_FROM:-$(seth rpc eth_coinbase)}
 
-test -z "$SKIP_BUILD" && dapp build
+dappBuild
 
 test -z "$ETH" && ETH=$(dapp create WETH9_)
 test -z "$PIP_ETH" && PIP_ETH=$(dapp create DSValue)

--- a/bin/lib/common.sh
+++ b/bin/lib/common.sh
@@ -16,11 +16,19 @@ message() {
     echo
 }
 
+dappBuild() {
+  [[ -n $SKIP_BUILD || -n $DAPP_SKIP_BUILD ]] && return
+
+  (cd "$BIN_DIR/.." || exit 1
+    dapp "$@" build
+  )
+}
+
 # Start verbose output
 set -x
 
 # Set exported variables
+export DAPP_OUT=${DAPP_OUT:-$BIN_DIR/../out}
 export ADDRESS_DIR=${ADDRESS_DIR:-$PWD}
 export ETH_GAS=${ETH_GAS:-"7000000"}
 unset SOLC_FLAGS
-

--- a/default.nix
+++ b/default.nix
@@ -18,18 +18,18 @@ let
     };
   };
 
-  deploy-core = mkScripts {
-    name = "dss-deploy-core";
+  optimized = mkScripts {
+    name = "dss-deploy-optimized";
     regex = [ "deploy-core" ];
     solidityPackages = [ this-optimize ];
   };
 
-  deploy-fabs = mkScripts {
-    name = "dss-deploy-fabs";
+  nonOptimized = mkScripts {
+    name = "dss-deploy-non-optimized";
     regex = [ "deploy-fab" "deploy-ilk.*" ];
     solidityPackages = [ this ];
   };
 in symlinkJoin {
   name = "dss-deploy";
-  paths = [ deploy-fabs deploy-core ];
+  paths = [ optimized nonOptimized ];
 }

--- a/default.nix
+++ b/default.nix
@@ -3,17 +3,33 @@
 }: with pkgs;
 
 let
-  inherit (callPackage ./nix/dapp.nix {}) this;
-in
+  inherit (callPackage ./nix/dapp.nix {}) this specs package;
 
-makerScriptPackage {
-  name = "dss-deploy";
-  src = ./bin;
+  this-optimize = package (specs.this // {
+    solcFlags = "--optimize";
+  });
 
-  solidityPackages = [ this ];
-
-  extraBins = [ git ];
-  scriptEnv = {
-    SKIP_BUILD = true;
+  mkScripts = { regex, name, solidityPackages }: makerScriptPackage {
+    inherit name solidityPackages;
+    src = lib.sourceByRegex ./bin (regex ++ [ ".*lib.*" ]);
+    extraBins = [ git ];
+    scriptEnv = {
+      SKIP_BUILD = true;
+    };
   };
+
+  deploy-core = mkScripts {
+    name = "dss-deploy-core";
+    regex = [ "deploy-core" ];
+    solidityPackages = [ this-optimize ];
+  };
+
+  deploy-fabs = mkScripts {
+    name = "dss-deploy-fabs";
+    regex = [ "deploy-fab" "deploy-ilk.*" ];
+    solidityPackages = [ this ];
+  };
+in symlinkJoin {
+  name = "dss-deploy";
+  paths = [ deploy-fabs deploy-core ];
 }

--- a/nix/dapp.nix
+++ b/nix/dapp.nix
@@ -114,7 +114,7 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    ds-pause_3d367e5 = rec {
+    ds-pause_e2ac2b0 = rec {
       name = "ds-pause";
       deps = {
         ds-chief = ds-chief_58a02ff;
@@ -124,9 +124,9 @@ let
         ds-token = ds-token_cee36a1;
       };
       repo' = {
-        name = "ds-pause-3d367e5-source";
+        name = "ds-pause-e2ac2b0-source";
         url = "https://github.com/dapphub/ds-pause";
-        rev = "3d367e541bb3e74bb115886f5c2903125e883b04";
+        rev = "e2ac2b057b5b9d54e4b9ebae2feef34b37223bc6";
         ref = "HEAD";
       };
       src' = fetchGit repo';
@@ -148,16 +148,16 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    dsr_587044e = rec {
+    dsr_1e1a19b = rec {
       name = "dsr";
       deps = {
         ds-test = ds-test_a4e4005;
-        dss = dss_7023787;
+        dss = dss_6e5651a;
       };
       repo' = {
-        name = "dsr-587044e-source";
+        name = "dsr-1e1a19b-source";
         url = "https://github.com/makerdao/dsr";
-        rev = "587044e0f3b09f9f69c479b470ba8f5554556567";
+        rev = "1e1a19b341ddf3998933f7944b23a38126c9c409";
         ref = "HEAD";
       };
       src' = fetchGit repo';
@@ -178,18 +178,17 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    dss_7023787 = rec {
+    dss_6e5651a = rec {
       name = "dss";
       deps = {
-        ds-note = ds-note_beef816;
         ds-test = ds-test_a4e4005;
         ds-token = ds-token_cee36a1;
         ds-value = ds-value_f307171;
       };
       repo' = {
-        name = "dss-7023787-source";
+        name = "dss-6e5651a-source";
         url = "https://github.com/makerdao/dss";
-        rev = "702378726d9b9ad0aa3477310a7f1a6ad790d768";
+        rev = "6e5651a85d829bed82d1608b67fea87491ee5550";
         ref = "HEAD";
       };
       src' = fetchGit repo';
@@ -317,29 +316,29 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    dss-deploy_b7c10aa = rec {
+    dss-deploy_6be42cf = rec {
       name = "dss-deploy";
       deps = {
         ds-auth = ds-auth_f783169;
         ds-guard = ds-guard_4678e1c;
         ds-note = ds-note_beef816;
-        ds-pause = ds-pause_3d367e5;
+        ds-pause = ds-pause_e2ac2b0;
         ds-roles = ds-roles_0138372;
         ds-test = ds-test_a4e4005;
         ds-token = ds-token_cee36a1;
         ds-weth = ds-weth_dfada5b;
-        dsr = dsr_587044e;
+        dsr = dsr_1e1a19b;
       };
       repo' = {
-        name = "dss-deploy-b7c10aa-source";
+        name = "dss-deploy-6be42cf-source";
         url = "git@github.com:makerdao/dss-deploy";
-        rev = "b7c10aae8ef25a8dcc84ffa98cbee94fea7ce3ed";
+        rev = "6be42cfa7781c86dbf1a1b4013f0583994bfb578";
         ref = "HEAD";
       };
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    this = dss-deploy_b7c10aa // { src' = ../.; src = ../src; };
+    this = dss-deploy_6be42cf // { src' = ../.; src = ../src; };
   };
 in {
   inherit package packageSpecs specs;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,5 +1,5 @@
 import (fetchGit {
   url = "https://github.com/makerdao/nixpkgs-pin";
-  rev = "475a4ca2eecb8b465eab3a0340874c49a9576deb";
+  rev = "2927c50733fc557f8c5da17a2229ba851afe171c";
   ref = "master";
 })


### PR DESCRIPTION
To be able to remove regexning of deploy scripts when using Nix as suggested in issue https://github.com/makerdao/testchain-dss-deployment-scripts/pull/35 we first need to make the deploy scripts in `dss-deploy` executable from any directory.

There was also a problem with the `solc --optimize` flag not being used when building `DssDeploy` with Nix.

