### PR TITLE
Add pause proxy address export

### DIFF
--- a/bin/deploy-core
+++ b/bin/deploy-core
@@ -68,6 +68,6 @@ export MCD_SPOT=0x$(seth call "$MCD_DEPLOY" "spotter()(address)")
 export MCD_POT=0x$(seth call "$MCD_DEPLOY" "pot()(address)")
 export MCD_END=0x$(seth call "$MCD_DEPLOY" "end()(address)")
 export MCD_PAUSE=0x$(seth call "$MCD_DEPLOY" "pause()(address)")
-export MCD_PAUSE=0x$(seth call "0x$(seth call "$MCD_DEPLOY" "pause()(address)")" "proxy()(address)")
+export MCD_PAUSE_PROXY=0x$(seth call "0x$(seth call "$MCD_DEPLOY" "pause()(address)")" "proxy()(address)")
 export MCD_DAI=0x$(seth call "$MCD_DEPLOY" "dai()(address)")
 EOF

--- a/bin/deploy-core
+++ b/bin/deploy-core
@@ -68,5 +68,6 @@ export MCD_SPOT=0x$(seth call "$MCD_DEPLOY" "spotter()(address)")
 export MCD_POT=0x$(seth call "$MCD_DEPLOY" "pot()(address)")
 export MCD_END=0x$(seth call "$MCD_DEPLOY" "end()(address)")
 export MCD_PAUSE=0x$(seth call "$MCD_DEPLOY" "pause()(address)")
+export MCD_PAUSE_PROXY=0x$(seth call "$MCD_PAUSE" "proxy()(address)")
 export MCD_DAI=0x$(seth call "$MCD_DEPLOY" "dai()(address)")
 EOF

--- a/bin/deploy-core
+++ b/bin/deploy-core
@@ -67,7 +67,7 @@ export MCD_FLOP=0x$(seth call "$MCD_DEPLOY" "flop()(address)")
 export MCD_SPOT=0x$(seth call "$MCD_DEPLOY" "spotter()(address)")
 export MCD_POT=0x$(seth call "$MCD_DEPLOY" "pot()(address)")
 export MCD_END=0x$(seth call "$MCD_DEPLOY" "end()(address)")
+export MCD_PAUSE=0x$(seth call "$MCD_DEPLOY" "pause()(address)")
 export MCD_PAUSE=0x$(seth call "0x$(seth call "$MCD_DEPLOY" "pause()(address)")" "proxy()(address)")
-export MCD_PAUSE_PROXY=0x$(seth call "$MCD_PAUSE" "proxy()(address)")
 export MCD_DAI=0x$(seth call "$MCD_DEPLOY" "dai()(address)")
 EOF

--- a/bin/deploy-core
+++ b/bin/deploy-core
@@ -67,7 +67,7 @@ export MCD_FLOP=0x$(seth call "$MCD_DEPLOY" "flop()(address)")
 export MCD_SPOT=0x$(seth call "$MCD_DEPLOY" "spotter()(address)")
 export MCD_POT=0x$(seth call "$MCD_DEPLOY" "pot()(address)")
 export MCD_END=0x$(seth call "$MCD_DEPLOY" "end()(address)")
-export MCD_PAUSE=0x$(seth call "$MCD_DEPLOY" "pause()(address)")
+export MCD_PAUSE=0x$(seth call "0x$(seth call "$MCD_DEPLOY" "pause()(address)")" "proxy()(address)")
 export MCD_PAUSE_PROXY=0x$(seth call "$MCD_PAUSE" "proxy()(address)")
 export MCD_DAI=0x$(seth call "$MCD_DEPLOY" "dai()(address)")
 EOF


### PR DESCRIPTION
The Pause Proxy address was not getting exported. This allows us to add it to the addresses.json for testchain.  