### PR TITLE
ISSUE-335: Explicitly declare compiler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - cachix use dapp
   - nix-env -f https://github.com/dapphub/dapptools/tarball/master -iA dapp
 script:
-  - dapp test
+  - dapp --use solc:0.5.11 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - nix-env -iA cachix -f https://cachix.org/api/v1/install
   - cachix use cachix
   - cachix use dapp
-  - nix-env -f https://github.com/dapphub/dapptools/tarball/master -iA dapp
+  - git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
+  - nix-env -f $HOME/.dapp/dapptools -iA dapp solc
 script:
   - dapp --use solc:0.5.11 test

--- a/nix/dapp.nix
+++ b/nix/dapp.nix
@@ -273,7 +273,7 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    dss_0059df7 = rec {
+    dss_407afdc = rec {
       name = "dss";
       deps = {
         ds-test = ds-test_a4e4005;
@@ -281,9 +281,9 @@ let
         ds-value = ds-value_f307171;
       };
       repo' = {
-        name = "dss-0059df7-source";
+        name = "dss-407afdc-source";
         url = "https://github.com/makerdao/dss";
-        rev = "0059df7fe4fc61c29bf0c0fbe9b3302c3b85ffca";
+        rev = "407afdcb034db841b25823a4aa312c005b3edf4d";
         ref = "HEAD";
       };
       src' = fetchGit repo';
@@ -328,7 +328,7 @@ let
         ds-test = ds-test_a4e4005;
         ds-token = ds-token_cee36a1;
         ds-weth = ds-weth_dfada5b;
-        dss = dss_0059df7;
+        dss = dss_407afdc;
         esm = esm_e0a85d6;
       };
       src' = ../.;

--- a/src/DssDeploy.sol
+++ b/src/DssDeploy.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity =0.5.11;
+pragma solidity 0.5.11;
 
 import {DSAuth, DSAuthority} from "ds-auth/auth.sol";
 import {DSPause} from "ds-pause/pause.sol";

--- a/src/DssDeploy.sol
+++ b/src/DssDeploy.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import {DSAuth, DSAuthority} from "ds-auth/auth.sol";
 import {DSPause} from "ds-pause/pause.sol";

--- a/src/DssDeploy.t.base.sol
+++ b/src/DssDeploy.t.base.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.5.11;
+pragma solidity 0.5.11;
 
 import {DSTest} from "ds-test/test.sol";
 import {DSToken} from "ds-token/token.sol";

--- a/src/DssDeploy.t.base.sol
+++ b/src/DssDeploy.t.base.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import {DSTest} from "ds-test/test.sol";
 import {DSToken} from "ds-token/token.sol";

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "./DssDeploy.t.base.sol";
 

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.5.11;
+pragma solidity 0.5.11;
 
 import "./DssDeploy.t.base.sol";
 

--- a/src/govActions.sol
+++ b/src/govActions.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.5.11;
+pragma solidity 0.5.11;
 
 contract Setter {
     function file(bytes32, address) public;

--- a/src/govActions.sol
+++ b/src/govActions.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 contract Setter {
     function file(bytes32, address) public;

--- a/src/join.sol
+++ b/src/join.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 import "dss/lib.sol";
 

--- a/src/join.sol
+++ b/src/join.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity =0.5.11;
+pragma solidity 0.5.11;
 
 import "dss/lib.sol";
 

--- a/src/tokens.sol
+++ b/src/tokens.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.5.11;
+pragma solidity 0.5.11;
 
 contract REP {
     function add(uint x, uint y) internal pure returns (uint z) {

--- a/src/tokens.sol
+++ b/src/tokens.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0;
+pragma solidity =0.5.11;
 
 contract REP {
     function add(uint x, uint y) internal pure returns (uint z) {


### PR DESCRIPTION
This PR locks solidity to a very specific version `0.5.11` in preparation for deployment. We wanted to make sure it was at least `0.5.7` to fix bugs in `ABIEncoderV2`. We discussed locking to `0.5.9` for `klab`, and ultimately decided to lock to `0.5.11`.