### PR TITLE
Add GemJoin6, standard token with configurable implementation

### DIFF
--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -834,7 +834,7 @@ contract DssDeployTest is DssDeployTestBase {
         }
     }
 
-    function testFailTUSD() public {
+    function testFailGemJoin6Join() public {
         DSValue pip = new DSValue();
         TUSD tusd = new TUSD(100 ether);
         GemJoin6 tusdJoin = new GemJoin6(address(vat), "TUSD", address(tusd));
@@ -846,6 +846,18 @@ contract DssDeployTest is DssDeployTestBase {
         tusd.setImplementation(0xCB9a11afDC6bDb92E4A6235959455F28758b34bA);
         // Fail here
         tusdJoin.join(address(this), 10 ether);
+    }
+
+    function testFailGemJoin6Exit() public {
+        DSValue pip = new DSValue();
+        TUSD tusd = new TUSD(100 ether);
+        GemJoin6 tusdJoin = new GemJoin6(address(vat), "TUSD", address(tusd));
+        dssDeploy.deployCollateral("TUSD", address(tusdJoin), address(pip));
+        tusd.approve(address(tusdJoin), uint(-1));
+        tusdJoin.join(address(this), 10 ether);
+        tusd.setImplementation(0xCB9a11afDC6bDb92E4A6235959455F28758b34bA);
+        // Fail here
+        tusdJoin.exit(address(this), 10 ether);
     }
 
     function testFailJoinAfterCageGemJoin2() public {

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -814,7 +814,7 @@ contract DssDeployTest is DssDeployTestBase {
         }
 
         {
-        TUSD tusd = new TUSD(100 ether, address(0));
+        TUSD tusd = new TUSD(100 ether);
         GemJoin6 tusdJoin = new GemJoin6(address(vat), "TUSD", address(tusd));
         assertEq(tusdJoin.dec(), 18);
 
@@ -836,7 +836,7 @@ contract DssDeployTest is DssDeployTestBase {
 
     function testFailTUSD() public {
         DSValue pip = new DSValue();
-        TUSD tusd = new TUSD(100 ether, address(0));
+        TUSD tusd = new TUSD(100 ether);
         GemJoin6 tusdJoin = new GemJoin6(address(vat), "TUSD", address(tusd));
         dssDeploy.deployCollateral("TUSD", address(tusdJoin), address(pip));
         tusd.approve(address(tusdJoin), uint(-1));

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -814,8 +814,8 @@ contract DssDeployTest is DssDeployTestBase {
         }
 
         {
-        TUSD tusd = new TUSD(100 ether);
-        GemJoin tusdJoin = new GemJoin(address(vat), "TUSD", address(tusd));
+        TUSD tusd = new TUSD(100 ether, address(0));
+        GemJoin6 tusdJoin = new GemJoin6(address(vat), "TUSD", address(tusd));
         assertEq(tusdJoin.dec(), 18);
 
         dssDeploy.deployCollateral("TUSD", address(tusdJoin), address(pip));
@@ -832,6 +832,20 @@ contract DssDeployTest is DssDeployTestBase {
         assertEq(tusd.balanceOf(address(tusdJoin)), 6 ether);
         assertEq(vat.gem("TUSD", address(this)), 6 ether);
         }
+    }
+
+    function testFailTUSD() public {
+        DSValue pip = new DSValue();
+        TUSD tusd = new TUSD(100 ether, address(0));
+        GemJoin6 tusdJoin = new GemJoin6(address(vat), "TUSD", address(tusd));
+        dssDeploy.deployCollateral("TUSD", address(tusdJoin), address(pip));
+        tusd.approve(address(tusdJoin), uint(-1));
+        assertEq(tusd.balanceOf(address(this)), 100 ether);
+        assertEq(tusd.balanceOf(address(tusdJoin)), 0);
+        assertEq(vat.gem("TUSD", address(this)), 0);
+        tusd.setImplementation(0xCB9a11afDC6bDb92E4A6235959455F28758b34bA);
+        // Fail here
+        tusdJoin.join(address(this), 10 ether);
     }
 
     function testFailJoinAfterCageGemJoin2() public {

--- a/src/join.sol
+++ b/src/join.sol
@@ -337,7 +337,7 @@ contract GemJoin6 is LibNote {
     function rely(address usr) external note auth { wards[usr] = 1; }
     function deny(address usr) external note auth { wards[usr] = 0; }
     modifier auth {
-        require(wards[msg.sender] == 1, "GemJoin/not-authorized");
+        require(wards[msg.sender] == 1, "GemJoin6/not-authorized");
         _;
     }
 

--- a/src/join.sol
+++ b/src/join.sol
@@ -333,7 +333,7 @@ contract GemLike6 {
 
 contract GemJoin6 is LibNote {
     // --- Auth ---
-    mapping (address => uint) public wards;
+    mapping (address => uint256) public wards;
     function rely(address usr) external note auth { wards[usr] = 1; }
     function deny(address usr) external note auth { wards[usr] = 0; }
     modifier auth {
@@ -347,7 +347,7 @@ contract GemJoin6 is LibNote {
     uint     public dec;
     uint     public live;  // Access Flag
 
-    mapping (address => bool) public implementations;
+    mapping (address => uint256) public implementations;
 
     constructor(address vat_, bytes32 ilk_, address gem_) public {
         wards[msg.sender] = 1;
@@ -355,25 +355,25 @@ contract GemJoin6 is LibNote {
         vat = VatLike(vat_);
         ilk = ilk_;
         gem = GemLike6(gem_);
-        setImplementation(gem.implementation(), true);
+        setImplementation(gem.implementation(), 1);
         dec = gem.decimals();
     }
     function cage() external note auth {
         live = 0;
     }
-    function setImplementation(address implementation, bool permitted) public auth note {
-        implementations[implementation] = permitted;
+    function setImplementation(address implementation, uint256 permitted) public auth note {
+        implementations[implementation] = permitted;  // 1 live, 0 disable
     }
     function join(address usr, uint wad) external note {
         require(live == 1, "GemJoin6/not-live");
         require(int(wad) >= 0, "GemJoin6/overflow");
-        require(implementations[gem.implementation()], "GemJoin6/implementation-invalid");
+        require(implementations[gem.implementation()] == 1, "GemJoin6/implementation-invalid");
         vat.slip(ilk, usr, int(wad));
         require(gem.transferFrom(msg.sender, address(this), wad), "GemJoin6/failed-transfer");
     }
     function exit(address usr, uint wad) external note {
         require(wad <= 2 ** 255, "GemJoin6/overflow");
-        require(implementations[gem.implementation()], "GemJoin6/implementation-invalid");
+        require(implementations[gem.implementation()] == 1, "GemJoin6/implementation-invalid");
         vat.slip(ilk, msg.sender, -int(wad));
         require(gem.transfer(usr, wad), "GemJoin6/failed-transfer");
     }

--- a/src/join.sol
+++ b/src/join.sol
@@ -318,6 +318,67 @@ contract GemJoin5 is LibNote {
     }
 }
 
+// GemJoin6
+// For a token with a proxy and implementation contract (like tUSD)
+//  If the implementation behind the proxy is changed, this prevents joins
+//   and exits until the implementation is reviewed and approved by governance.
+
+contract GemLike6 {
+    function decimals() public view returns (uint);
+    function balanceOf(address) public returns (uint256);
+    function transfer(address, uint256) public returns (bool);
+    function transferFrom(address,address,uint) public returns (bool);
+    function implementation() public view returns (address);
+}
+
+contract GemJoin6 is LibNote {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address usr) external note auth { wards[usr] = 1; }
+    function deny(address usr) external note auth { wards[usr] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "GemJoin/not-authorized");
+        _;
+    }
+
+    VatLike  public vat;
+    bytes32  public ilk;
+    GemLike6 public gem;
+    uint     public dec;
+    uint     public live;  // Access Flag
+
+    mapping (address => bool) public implementations;
+
+    constructor(address vat_, bytes32 ilk_, address gem_) public {
+        wards[msg.sender] = 1;
+        live = 1;
+        vat = VatLike(vat_);
+        ilk = ilk_;
+        gem = GemLike6(gem_);
+        setImplementation(gem.implementation(), true);
+        dec = gem.decimals();
+    }
+    function cage() external note auth {
+        live = 0;
+    }
+    function setImplementation(address implementation, bool permitted) public auth note {
+        implementations[implementation] = permitted;
+    }
+    function join(address usr, uint wad) external note {
+        require(live == 1, "GemJoin6/not-live");
+        require(int(wad) >= 0, "GemJoin6/overflow");
+        require(implementations[gem.implementation()], "GemJoin6/implementation-invalid");
+        vat.slip(ilk, usr, int(wad));
+        require(gem.transferFrom(msg.sender, address(this), wad), "GemJoin6/failed-transfer");
+    }
+    function exit(address usr, uint wad) external note {
+        require(wad <= 2 ** 255, "GemJoin6/overflow");
+        require(implementations[gem.implementation()], "GemJoin6/implementation-invalid");
+        vat.slip(ilk, msg.sender, -int(wad));
+        require(gem.transfer(usr, wad), "GemJoin6/failed-transfer");
+    }
+}
+
 // AuthGemJoin
 // For a token that needs restriction on the sources which are able to execute the join function (like SAI through Migration contract)
 

--- a/src/tokens.sol
+++ b/src/tokens.sol
@@ -490,10 +490,10 @@ contract TUSD {
     mapping (address => uint256)                       _balances;
     mapping (address => mapping (address => uint256))  _approvals;
 
-    constructor(uint supply, address initialImplementation) public {
+    constructor(uint supply) public {
         _balances[msg.sender] = supply;
         _supply = supply;
-        setImplementation(initialImplementation);
+        setImplementation(address(this));
     }
 
     function setImplementation(address newImplementation) public {

--- a/src/tokens.sol
+++ b/src/tokens.sol
@@ -485,13 +485,19 @@ contract TUSD {
     string  public  name = "TrueUSD";
     string  public  symbol = "TUSD";
     uint8   public  decimals = 18;
+    address public  implementation;
     uint256                                            _supply;
     mapping (address => uint256)                       _balances;
     mapping (address => mapping (address => uint256))  _approvals;
 
-    constructor(uint supply) public {
+    constructor(uint supply, address initialImplementation) public {
         _balances[msg.sender] = supply;
         _supply = supply;
+        setImplementation(initialImplementation);
+    }
+
+    function setImplementation(address newImplementation) public {
+        implementation = newImplementation;
     }
 
     function totalSupply() public view returns (uint256) {


### PR DESCRIPTION
This adds a proposed GemJoin6 adapter for standard tokens that follow OpenZeppelin's [OwnedUpgradeabilityProxy](https://blog.openzeppelin.com/proxy-patterns/) pattern.

Since these have an configurable implementation contract behind the static public-facing address, it's possible that the token code that has been audited by the collateral onboarding team could change after the collateral type has been added to MCD.

This adds an authorized function to set or remove implementations, and require checks inside of the join and exit functions. This would have the effect of locking the adapter immediately if the implementation contract is changed to an unknown or unauthorized implementation.

A token team could advise the MakerDAO ahead of time of an upcoming implementation change, which can then be added to the approval mapping by governance after an audit. In the event that an implementation changes maliciously or without forewarning, this would prevent funds from entering or being exited until the new code is reviewed.