### PR TITLE
Add AuthGemJoin 2

### DIFF
--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -1051,7 +1051,7 @@ contract DssDeployTest is DssDeployTestBase {
         assertEq(vat.gem("USDC", address(this)), 6 ether);
     }
 
-    function testFailAuthJoin2_join() public {
+    function testFailAuthJoin2() public {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
@@ -1063,21 +1063,6 @@ contract DssDeployTest is DssDeployTestBase {
         usdc.approve(address(usdcJoin), uint(-1));
         usdcJoin.deny(address(this));
         usdcJoin.join(address(this), 10);
-    }
-
-    function testFailAuthJoin2_exit() public {
-        deployKeepAuth();
-        DSValue pip = new DSValue();
-
-        USDC usdc = new USDC(10);
-        AuthGemJoin2 usdcJoin = new AuthGemJoin2(address(vat), "USDC", address(usdc));
-
-        dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
-
-        usdc.approve(address(usdcJoin), uint(-1));
-        usdcJoin.join(address(this), 10);
-        usdcJoin.deny(address(this));
-        usdcJoin.exit(address(this), 10);
     }
 
     function testAuth() public {

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -977,7 +977,23 @@ contract DssDeployTest is DssDeployTestBase {
         saiJoin.join(address(this), 10);
     }
 
-    function testTokenSai() public {
+    function testFailJoinAfterCageAuthGemJoin2() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken usdc = new DSToken("USDC");
+        usdc.mint(20);
+        AuthGemJoin2 usdcJoin = new AuthGemJoin2(address(vat), "USDC", address(usdc));
+
+        dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
+
+        usdc.approve(address(usdcJoin), uint(-1));
+        usdcJoin.join(address(this), 10);
+        usdcJoin.cage();
+        usdcJoin.join(address(this), 10);
+    }
+
+    function testAuthJoin() public {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
@@ -1000,7 +1016,7 @@ contract DssDeployTest is DssDeployTestBase {
         assertEq(vat.gem("SAI", address(this)), 6);
     }
 
-    function testFailTokenSai() public {
+    function testFailAuthJoin() public {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
@@ -1013,6 +1029,44 @@ contract DssDeployTest is DssDeployTestBase {
         sai.approve(address(saiJoin), uint(-1));
         saiJoin.deny(address(this));
         saiJoin.join(address(this), 10);
+    }
+
+    function testAuthJoin2() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken usdc = new DSToken("USDC");
+        usdc.mint(10);
+        AuthGemJoin usdcJoin = new AuthGemJoin(address(vat), "USDC", address(usdc));
+        assertEq(usdcJoin.dec(), 18);
+
+        dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
+
+        usdc.approve(address(usdcJoin), uint(-1));
+        assertEq(usdc.balanceOf(address(usdcJoin)), 0);
+        assertEq(vat.gem("USDC", address(this)), 0);
+        usdcJoin.join(address(this), 10);
+        assertEq(usdc.balanceOf(address(usdcJoin)), 10);
+        assertEq(vat.gem("USDC", address(this)), 10);
+        usdcJoin.deny(address(this)); // Check there is no need of authorization to exit
+        usdcJoin.exit(address(this), 4);
+        assertEq(usdc.balanceOf(address(usdcJoin)), 6);
+        assertEq(vat.gem("USDC", address(this)), 6);
+    }
+
+    function testFailAuthJoin2() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        DSToken usdc = new DSToken("USDC");
+        usdc.mint(10);
+        AuthGemJoin usdcJoin = new AuthGemJoin(address(vat), "USDC", address(usdc));
+
+        dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
+
+        usdc.approve(address(usdcJoin), uint(-1));
+        usdcJoin.deny(address(this));
+        usdcJoin.join(address(this), 10);
     }
 
     function testAuth() public {

--- a/src/DssDeploy.t.sol
+++ b/src/DssDeploy.t.sol
@@ -935,7 +935,7 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
-        USDC usdc = new USDC(100 ether);
+        USDC usdc = new USDC(100 * 10 ** 6);
         GemJoin5 usdcJoin = new GemJoin5(address(vat), "USDC", address(usdc));
 
         dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
@@ -981,8 +981,7 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
-        DSToken usdc = new DSToken("USDC");
-        usdc.mint(20);
+        USDC usdc = new USDC(20);
         AuthGemJoin2 usdcJoin = new AuthGemJoin2(address(vat), "USDC", address(usdc));
 
         dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
@@ -1035,38 +1034,50 @@ contract DssDeployTest is DssDeployTestBase {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
-        DSToken usdc = new DSToken("USDC");
-        usdc.mint(10);
-        AuthGemJoin usdcJoin = new AuthGemJoin(address(vat), "USDC", address(usdc));
-        assertEq(usdcJoin.dec(), 18);
+        USDC usdc = new USDC(10 * 10 ** 6);
+        AuthGemJoin2 usdcJoin = new AuthGemJoin2(address(vat), "USDC", address(usdc));
+        assertEq(usdcJoin.dec(), 6);
 
         dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
 
         usdc.approve(address(usdcJoin), uint(-1));
         assertEq(usdc.balanceOf(address(usdcJoin)), 0);
         assertEq(vat.gem("USDC", address(this)), 0);
-        usdcJoin.join(address(this), 10);
-        assertEq(usdc.balanceOf(address(usdcJoin)), 10);
-        assertEq(vat.gem("USDC", address(this)), 10);
-        usdcJoin.deny(address(this)); // Check there is no need of authorization to exit
-        usdcJoin.exit(address(this), 4);
-        assertEq(usdc.balanceOf(address(usdcJoin)), 6);
-        assertEq(vat.gem("USDC", address(this)), 6);
+        usdcJoin.join(address(this), 10 * 10 ** 6);
+        assertEq(usdc.balanceOf(address(usdcJoin)), 10 * 10 ** 6);
+        assertEq(vat.gem("USDC", address(this)), 10 ether);
+        usdcJoin.exit(address(this), 4 * 10 ** 6);
+        assertEq(usdc.balanceOf(address(usdcJoin)), 6 * 10 ** 6);
+        assertEq(vat.gem("USDC", address(this)), 6 ether);
     }
 
-    function testFailAuthJoin2() public {
+    function testFailAuthJoin2_join() public {
         deployKeepAuth();
         DSValue pip = new DSValue();
 
-        DSToken usdc = new DSToken("USDC");
-        usdc.mint(10);
-        AuthGemJoin usdcJoin = new AuthGemJoin(address(vat), "USDC", address(usdc));
+        USDC usdc = new USDC(10);
+        AuthGemJoin2 usdcJoin = new AuthGemJoin2(address(vat), "USDC", address(usdc));
 
         dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
 
         usdc.approve(address(usdcJoin), uint(-1));
         usdcJoin.deny(address(this));
         usdcJoin.join(address(this), 10);
+    }
+
+    function testFailAuthJoin2_exit() public {
+        deployKeepAuth();
+        DSValue pip = new DSValue();
+
+        USDC usdc = new USDC(10);
+        AuthGemJoin2 usdcJoin = new AuthGemJoin2(address(vat), "USDC", address(usdc));
+
+        dssDeploy.deployCollateral("USDC", address(usdcJoin), address(pip));
+
+        usdc.approve(address(usdcJoin), uint(-1));
+        usdcJoin.join(address(this), 10);
+        usdcJoin.deny(address(this));
+        usdcJoin.exit(address(this), 10);
     }
 
     function testAuth() public {

--- a/src/join.sol
+++ b/src/join.sol
@@ -429,7 +429,7 @@ contract AuthGemJoin is LibNote {
 }
 
 // AuthGemJoin2
-// For a token that needs restriction on the sources which are able to execute the join and exit functions,
+// For a token that needs restriction on the sources which are able to execute join function,
 // has a lower precision than 18 and it has decimals (like USDC through PSM)
 
 contract GemLikeAuth2 {
@@ -477,7 +477,7 @@ contract AuthGemJoin2 is LibNote {
         require(gem.transferFrom(msg.sender, address(this), wad), "AuthGemJoin2/failed-transfer");
     }
 
-    function exit(address guy, uint wad) public auth note {
+    function exit(address guy, uint wad) public note {
         uint wad18 = mul(wad, 10 ** (18 - dec));
         require(int(wad18) >= 0, "AuthGemJoin2/overflow");
         vat.slip(ilk, msg.sender, -int(wad18));

--- a/src/join.sol
+++ b/src/join.sol
@@ -429,7 +429,7 @@ contract AuthGemJoin is LibNote {
 }
 
 // AuthGemJoin2
-// For a token that needs restriction on the sources which are able to execute the join function,
+// For a token that needs restriction on the sources which are able to execute the join and exit functions,
 // has a lower precision than 18 and it has decimals (like USDC through PSM)
 
 contract GemLikeAuth2 {

--- a/src/join.sol
+++ b/src/join.sol
@@ -432,10 +432,10 @@ contract AuthGemJoin is LibNote {
 // For a token that needs restriction on the sources which are able to execute join function,
 // has a lower precision than 18 and it has decimals (like USDC through PSM)
 
-contract GemLikeAuth2 {
-    function decimals() public view returns (uint);
-    function transfer(address,uint) public returns (bool);
-    function transferFrom(address,address,uint) public returns (bool);
+interface GemLikeAuth2 {
+    function decimals() external view returns (uint);
+    function transfer(address,uint) external returns (bool);
+    function transferFrom(address,address,uint) external returns (bool);
 }
 
 contract AuthGemJoin2 is LibNote {

--- a/src/join.sol
+++ b/src/join.sol
@@ -427,3 +427,60 @@ contract AuthGemJoin is LibNote {
         require(gem.transfer(usr, wad), "AuthGemJoin/failed-transfer");
     }
 }
+
+// AuthGemJoin2
+// For a token that needs restriction on the sources which are able to execute the join function,
+// has a lower precision than 18 and it has decimals (like USDC through PSM)
+
+contract GemLikeAuth2 {
+    function decimals() public view returns (uint);
+    function transfer(address,uint) public returns (bool);
+    function transferFrom(address,address,uint) public returns (bool);
+}
+
+contract AuthGemJoin2 is LibNote {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address usr) external note auth { wards[usr] = 1; }
+    function deny(address usr) external note auth { wards[usr] = 0; }
+    modifier auth { require(wards[msg.sender] == 1); _; }
+
+    VatLike         public vat;
+    bytes32         public ilk;
+    GemLikeAuth2    public gem;
+    uint            public dec;
+    uint            public live;  // Access Flag
+
+    constructor(address vat_, bytes32 ilk_, address gem_) public {
+        gem = GemLikeAuth2(gem_);
+        dec = gem.decimals();
+        require(dec < 18, "AuthGemJoin2/decimals-18-or-higher");
+        wards[msg.sender] = 1;
+        live = 1;
+        vat = VatLike(vat_);
+        ilk = ilk_;
+    }
+
+    function cage() external note auth {
+        live = 0;
+    }
+
+    function mul(uint x, uint y) internal pure returns (uint z) {
+        require(y == 0 || (z = x * y) / y == x, "AuthGemJoin2/overflow");
+    }
+
+    function join(address urn, uint wad) public auth note {
+        require(live == 1, "AuthGemJoin2/not-live");
+        uint wad18 = mul(wad, 10 ** (18 - dec));
+        require(int(wad18) >= 0, "AuthGemJoin2/overflow");
+        vat.slip(ilk, urn, int(wad18));
+        require(gem.transferFrom(msg.sender, address(this), wad), "AuthGemJoin2/failed-transfer");
+    }
+
+    function exit(address guy, uint wad) public auth note {
+        uint wad18 = mul(wad, 10 ** (18 - dec));
+        require(int(wad18) >= 0, "AuthGemJoin2/overflow");
+        vat.slip(ilk, msg.sender, -int(wad18));
+        require(gem.transfer(guy, wad), "AuthGemJoin2/failed-transfer");
+    }
+}


### PR DESCRIPTION
Exact same adapter than `GemJoin5` but with `auth` in `join` and `exit` methods (hybrid between `GemJoin5` and `AuthGemJoin`). We might want to add the `implementation` check as well.